### PR TITLE
Use correct return type for ::read

### DIFF
--- a/src/PhysicalAioInput.cpp
+++ b/src/PhysicalAioInput.cpp
@@ -266,7 +266,7 @@ public:
             int fds_ready = select(fd+1, &readFdSet, nullptr, nullptr, &rdTimeout);
             if (fds_ready > 0) {
                 if (FD_ISSET(fd, &readFdSet)) {
-                    size_t nb = ::read(fd, buf, rdCnt);
+                    ssize_t nb = ::read(fd, buf, rdCnt);
                     if (nb > 0) {
                         // Making progress on the read.
                         total += nb;


### PR DESCRIPTION
Store result of ::read to ssize_t, consistent with documentation, rather
than size_t.  The latter type caused -1 results from ::read to cast to
a large integer value, waiting for a large number of bytes that would've
never arrived.
#39 