### PR TITLE
Fix Dangling Reference

### DIFF
--- a/src/PhysicalAioInput.cpp
+++ b/src/PhysicalAioInput.cpp
@@ -919,6 +919,9 @@ public:
                 }
                 if(lastBlock && buf.size() <= 1)
                 {
+                    // Manually unpin before changing the iterator state, otherwise the PinBuffer's chunk
+                    // reference will dangle and cause a crash.
+                    pinScope.unPin();
                     ++(*inputIterator);
                     continue;
                 }


### PR DESCRIPTION
When we reach the last block for a given input and the buffer size is
less-than one, manually unpin the chunk via the `PinBuffer` before
changing the iterator state; otherwise, the `PinBuffer`'s chunk reference
will dangle and cause a crash during the `PinBuffer`'s destructor.